### PR TITLE
Convert logging to hash and log total lock time

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ MasterLock.start
 
 See [documentation](http://www.rubydoc.info/gems/master_lock) for advanced usage.
 
+## Example Config
+
+```ruby
+MasterLock.configure do |config|
+  config.redis = $redis
+  config.logger.level = ENV['APP_ENV'] == 'test' ? :info : :debug
+
+  # The log formatter given must be able to accept hashes.
+  config.logger.formatter = proc do |_serverity, _time, _progname, msg|
+    "#{msg.to_json}\n"
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/master_lock/registry.rb
+++ b/lib/master_lock/registry.rb
@@ -73,17 +73,24 @@ module MasterLock
         if !registration.thread.alive?
           registration.released = true
           MasterLock.logger.info(
-            "Releasing lock #{lock_key} after owning thread terminated"
+            lock_id: lock_key,
+            message: 'Releasing lock after owning thread terminated.'
           )
         elsif !registration.released &&
             registration.acquired_at + registration.extend_interval < time
           lock_key = registration.lock.key
           if registration.lock.extend
             registration.acquired_at = time
-            MasterLock.logger.debug("Renewed lease on lock #{lock_key}")
+            MasterLock.logger.debug(
+              lock_id: lock_key,
+              message: 'Renewed lease on lock.'
+            )
           else
             registration.released = true
-            MasterLock.logger.warn("Could not renew lease on lock #{lock_key}")
+            MasterLock.logger.warn(
+              lock_id: lock_key,
+              message: 'Could not renew lease on lock.'
+            )
           end
         end
       end


### PR DESCRIPTION
Hashes can be useful for specialized logging pipelines.

We log the total lock time because it can be useful to
assess performance and traffic on certain resources.

⚠️ This branch was accidentally deleted. ⚠️ 