### PR TITLE
[builds] bump ruby + bundler to make builds operate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.6.5
 services:
   - redis-server
-before_install: gem install bundler -v 1.13.1
+before_install: gem install bundler -v 2.1.4

--- a/master_lock.gemspec
+++ b/master_lock.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "redis", ">= 3.0", "< 5"
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
* Fixes builds by bumping Ruby + Bundler versions to more modern ones.

Builds pass now (vs. error'ing): https://travis-ci.org/github/coinbase/master_lock/builds/674999659.