### PR TITLE
Pass backend's config as arg to RedisLock

### DIFF
--- a/lib/master_lock/backend.rb
+++ b/lib/master_lock/backend.rb
@@ -40,6 +40,7 @@ module MasterLock
           redis: config.redis,
           key: key,
           ttl: ttl,
+          cluster: config.cluster,
           owner: generate_owner
       )
       if !lock.acquire(timeout: acquire_timeout)

--- a/lib/master_lock/backend.rb
+++ b/lib/master_lock/backend.rb
@@ -37,10 +37,9 @@ module MasterLock
       end
 
       lock = RedisLock.new(
-          redis: config.redis,
+          config: config,
           key: key,
           ttl: ttl,
-          cluster: config.cluster,
           owner: generate_owner
       )
       if !lock.acquire(timeout: acquire_timeout)

--- a/lib/master_lock/redis_lock.rb
+++ b/lib/master_lock/redis_lock.rb
@@ -98,9 +98,9 @@ module MasterLock
       # Key hash tags are a way to ensure multiple keys are allocated in the same hash slot.
       # This allows our redis operations to work with clusters
       if config.cluster
-        "{#{MasterLock.config.key_prefix}}:#{key}"
+        "{#{config.key_prefix}}:#{key}"
       else
-        "#{MasterLock.config.key_prefix}:#{key}"
+        "#{config.key_prefix}:#{key}"
       end
     end
 

--- a/lib/master_lock/redis_lock.rb
+++ b/lib/master_lock/redis_lock.rb
@@ -10,8 +10,8 @@ module MasterLock
   class RedisLock
     DEFAULT_SLEEP_INTERVAL = 0.1
 
-    # @return [Redis] the Redis connection used to manage lock
-    attr_reader :redis
+    # @return [Config] backend's config which includes redis connection used to manage lock
+    attr_reader :config
 
     # @return [String] the unique identifier for the locked resource
     attr_reader :key
@@ -22,22 +22,17 @@ module MasterLock
     # @return [Fixnum] the lifetime of the lock in seconds
     attr_reader :ttl
 
-    # @return [Boolean] whether this Redis is clustered or not
-    attr_reader :cluster
-
     def initialize(
-      redis:,
+      config:,
       key:,
       owner:,
       ttl:,
-      cluster:,
       sleep_interval: DEFAULT_SLEEP_INTERVAL
     )
-      @redis = redis
+      @config = config
       @key = key
       @owner = owner
       @ttl = ttl
-      @cluster = cluster
       @sleep_interval = sleep_interval
     end
 
@@ -102,11 +97,15 @@ module MasterLock
     def redis_key
       # Key hash tags are a way to ensure multiple keys are allocated in the same hash slot.
       # This allows our redis operations to work with clusters
-      if cluster
+      if config.cluster
         "{#{MasterLock.config.key_prefix}}:#{key}"
       else
         "#{MasterLock.config.key_prefix}:#{key}"
       end
+    end
+
+    def redis
+      config.redis
     end
   end
 end

--- a/lib/master_lock/redis_lock.rb
+++ b/lib/master_lock/redis_lock.rb
@@ -95,13 +95,7 @@ module MasterLock
     end
 
     def redis_key
-      # Key hash tags are a way to ensure multiple keys are allocated in the same hash slot.
-      # This allows our redis operations to work with clusters
-      if config.cluster
-        "{#{config.key_prefix}}:#{key}"
-      else
-        "#{config.key_prefix}:#{key}"
-      end
+      "#{config.key_prefix}:#{key}"
     end
 
     def redis

--- a/lib/master_lock/redis_lock.rb
+++ b/lib/master_lock/redis_lock.rb
@@ -22,17 +22,22 @@ module MasterLock
     # @return [Fixnum] the lifetime of the lock in seconds
     attr_reader :ttl
 
+    # @return [Boolean] whether this Redis is clustered or not
+    attr_reader :cluster
+
     def initialize(
       redis:,
       key:,
       owner:,
       ttl:,
+      cluster:,
       sleep_interval: DEFAULT_SLEEP_INTERVAL
     )
       @redis = redis
       @key = key
       @owner = owner
       @ttl = ttl
+      @cluster = cluster
       @sleep_interval = sleep_interval
     end
 
@@ -97,7 +102,7 @@ module MasterLock
     def redis_key
       # Key hash tags are a way to ensure multiple keys are allocated in the same hash slot.
       # This allows our redis operations to work with clusters
-      if MasterLock.config.cluster
+      if cluster
         "{#{MasterLock.config.key_prefix}}:#{key}"
       else
         "#{MasterLock.config.key_prefix}:#{key}"

--- a/lib/master_lock/version.rb
+++ b/lib/master_lock/version.rb
@@ -1,3 +1,3 @@
 module MasterLock
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/spec/master_lock/redis_lock_spec.rb
+++ b/spec/master_lock/redis_lock_spec.rb
@@ -60,11 +60,9 @@ RSpec.describe MasterLock::RedisLock, redis: true, cluster: true do
     it "returns true when lock can be acquired" do
       expect(lock1.acquire(timeout: 0)).to eq(true)
       expect(redis.get('masterlock:key')).to_not be_nil
-      expect(redis.get('{masterlock}:key')).to be_nil
       # Cluster test
       expect(lock3.acquire(timeout: 0)).to eq(true)
-      expect(cluster.get('masterlock:key')).to be_nil
-      expect(cluster.get('{masterlock}:key')).to_not be_nil
+      expect(cluster.get('masterlock:key')).to_not be_nil
     end
 
     it "returns false when lock can not be acquired" do
@@ -138,29 +136,23 @@ RSpec.describe MasterLock::RedisLock, redis: true, cluster: true do
     it "returns true when lock is held by owner" do
       lock1.acquire(timeout: 0)
       expect(redis.get('masterlock:key')).to_not be_nil
-      expect(redis.get('{masterlock}:key')).to be_nil
       expect(lock1.release).to eq(true)
       expect(redis.get('masterlock:key')).to be_nil
-      expect(redis.get('{masterlock}:key')).to be_nil
       # Cluster test
       lock3.acquire(timeout: 0)
-      expect(cluster.get('masterlock:key')).to be_nil
-      expect(cluster.get('{masterlock}:key')).to_not be_nil
+      expect(cluster.get('masterlock:key')).to_not be_nil
       expect(lock3.release).to eq(true)
       expect(cluster.get('masterlock:key')).to be_nil
-      expect(cluster.get('{masterlock}:key')).to be_nil
     end
 
     it "returns false when lock is held by another owner" do
       lock2.acquire(timeout: 0)
       expect(lock1.release).to eq(false)
       expect(redis.get('masterlock:key')).to_not be_nil
-      expect(redis.get('{masterlock}:key')).to be_nil
       # Cluster test
       lock4.acquire(timeout: 0)
       expect(lock3.release).to eq(false)
-      expect(cluster.get('masterlock:key')).to be_nil
-      expect(cluster.get('{masterlock}:key')).to_not be_nil
+      expect(cluster.get('masterlock:key')).to_not be_nil
     end
 
     it "returns false when lock is not held" do

--- a/spec/master_lock/redis_lock_spec.rb
+++ b/spec/master_lock/redis_lock_spec.rb
@@ -1,17 +1,34 @@
 require 'spec_helper'
 
 RSpec.describe MasterLock::RedisLock, redis: true, cluster: true do
+  let(:redis_backend) do
+    b = MasterLock::Backend.new
+    b.configure do |config|
+      config.redis = redis
+      config.cluster = false
+    end
+    b
+  end
+  let(:cluster_backend) do
+    b = MasterLock::Backend.new
+    b.configure do |config|
+      config.redis = cluster
+      config.cluster = true
+    end
+    b
+  end
+
   let(:lock1) do
-    described_class.new(redis: redis, key: "key", owner: "owner1", ttl: 0.1, cluster: false)
+    described_class.new(config: redis_backend.config, key: "key", owner: "owner1", ttl: 0.1)
   end
   let(:lock2) do
-    described_class.new(redis: redis, key: "key", owner: "owner2", ttl: 0.1, cluster: false)
+    described_class.new(config: redis_backend.config, key: "key", owner: "owner2", ttl: 0.1)
   end
   let(:lock3) do
-    described_class.new(redis: cluster, key: "key", owner: "owner3", ttl: 0.1, cluster: true)
+    described_class.new(config: cluster_backend.config, key: "key", owner: "owner3", ttl: 0.1)
   end
   let(:lock4) do
-    described_class.new(redis: cluster, key: "key", owner: "owner4", ttl: 0.1, cluster: true)
+    described_class.new(config: cluster_backend.config, key: "key", owner: "owner4", ttl: 0.1)
   end
 
   before do

--- a/spec/master_lock_spec.rb
+++ b/spec/master_lock_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe MasterLock, redis: true do
   describe '.started?' do
     before do
-      MasterLock.instance_eval('@registry = nil')
+      MasterLock.backend.instance_eval('@registry = nil')
     end
 
     subject { described_class.started? }


### PR DESCRIPTION
* Stop passing MasterLock.config.cluster around and use `config` arg for RedisLock instead
* cleaned up specs, more assertions around contents within redis
* bumped version