### PR TITLE
Clean up unused cluster var

### DIFF
--- a/lib/master_lock.rb
+++ b/lib/master_lock.rb
@@ -33,8 +33,7 @@ module MasterLock
     :key_prefix,
     :redis,
     :sleep_time,
-    :ttl,
-    :cluster
+    :ttl
   )
 
   class << self

--- a/lib/master_lock/backend.rb
+++ b/lib/master_lock/backend.rb
@@ -99,7 +99,6 @@ module MasterLock
         @config.key_prefix = DEFAULT_KEY_PREFIX
         @config.sleep_time = DEFAULT_SLEEP_TIME
         @config.ttl = DEFAULT_TTL
-        @config.cluster = false
       end
       @config
     end

--- a/lib/master_lock/version.rb
+++ b/lib/master_lock/version.rb
@@ -1,3 +1,3 @@
 module MasterLock
-  VERSION = "0.12.1"
+  VERSION = "0.12.2"
 end

--- a/spec/master_lock/redis_lock_spec.rb
+++ b/spec/master_lock/redis_lock_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe MasterLock::RedisLock, redis: true, cluster: true do
     b = MasterLock::Backend.new
     b.configure do |config|
       config.redis = redis
-      config.cluster = false
     end
     b
   end
@@ -13,7 +12,6 @@ RSpec.describe MasterLock::RedisLock, redis: true, cluster: true do
     b = MasterLock::Backend.new
     b.configure do |config|
       config.redis = cluster
-      config.cluster = true
     end
     b
   end
@@ -29,11 +27,6 @@ RSpec.describe MasterLock::RedisLock, redis: true, cluster: true do
   end
   let(:lock4) do
     described_class.new(config: cluster_backend.config, key: "key", owner: "owner4", ttl: 0.1)
-  end
-
-  before do
-    clean_redis
-    clean_cluster
   end
 
   describe "#redis basic tests" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,7 +62,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-  config.include RedisTest, redis: true, cluster: true
+  config.include RedisTest
 
   config.before(:each, redis: true) do
     clean_redis
@@ -75,5 +75,4 @@ end
 
 MasterLock.configure do |config|
   config.logger.level = :info
-  config.cluster = false
 end


### PR DESCRIPTION
We no longer use `cluster` boolean.

Specs pass.

```
ds:~/src/github/master_lock (fix2)$ bundle exec rspec
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.

Randomized with seed 29260

MasterLock::RedisLock
  #cluster basic tests
    starts empty and then works
  #release
    returns false when lock is not held
    returns false when lock is held by another owner
    changes the lock to be unowned
    returns true when lock is held by owner
  #extend
    resets the expiration time
    returns true when lock is held by owner
    returns false when lock is not held
    returns false when lock is held by another owner
  #acquire
    returns false when lock can not be acquired
    returns false if the same owner already has the lock
    attempts to acquire the lock repeatedly until timeout
    returns true when lock can be acquired
  #redis basic tests
    starts empty and then works

MasterLock::Registry
  #unregister
    marks the lock as released
  #extend_locks
    does not attempt to extend recently acquired locks
    removes the locks from the registered list after it has been released
    extends locks that have been held longer than the extend_interval
W, [2021-03-05T17:16:40.280565 #38843]  WARN -- MasterLock: Could not renew lease on lock test
    removes the locks from the registered list after it has expired
I, [2021-03-05T17:16:40.281097 #38843]  INFO -- MasterLock: Releasing lock test after owning thread terminated
    removes the locks from the registered list if the owning thread dies
    does not remove active locks
  #register
    tracks the registered lock
    returns the registered struct

MasterLock
  .started?
    is expected to be falsy
    when configured and started
      is expected to be truthy
  when configured and started
    allows a lock to be acquired after it was released
    does not allow a lock to be acquired multiple times
    extends held locks automatically
    .synchronize
      raises an ArgumentError when ttl is less than extend_interval
      returns the result of the block
      raises an ArgumentError when ttl is less than extend_interval
      when the :if option is false
        returns the result of the block
        does not obtain the lock

Finished in 1.57 seconds (files took 0.35475 seconds to load)
33 examples, 0 failures

Randomized with seed 29260

[Coveralls] Outside the CI environment, not sending data.
```